### PR TITLE
BAH-2758 | Update validation json to accept single character sector

### DIFF
--- a/openmrs/apps/registration/app.json
+++ b/openmrs/apps/registration/app.json
@@ -39,7 +39,7 @@
             "phoneNumber" : {"pattern" : "^([+]91[1-9]{1}[0-9]{9})$", "errorMessage" : "Phone Number should be 10 digits with prefix +91 eg:+91xxxxxxxxxx"},
             "alternatePhoneNumber" : {"pattern" : "^([+]91[1-9]{1}[0-9]{9})$", "errorMessage" : "Phone Number should be 10 digits with prefix +91 eg:+91xxxxxxxxxx"},
             "address1":{"pattern":"^[a-zA-Z0-9\\s'\\-\\/]{1,}", "errorMessage":"Only Alphanumerics and following special characters are allowed. Special characters - [ '-/]"},
-            "address2":{"pattern":"^[a-zA-Z0-9\\s,'\\-.\\/]{2,}", "errorMessage":"Only Alphanumerics and following special characters are allowed. Special characters - [ ,'-./]"},
+            "address2":{"pattern":"^[a-zA-Z0-9\\s,'\\-.\\/]{1,}", "errorMessage":"Only Alphanumerics and following special characters are allowed. Special characters - [ ,'-./]"},
             "cityVillage":{"pattern":"^[a-zA-Z0-9\\s,'\\-.\\/]{2,}", "errorMessage":"Only Alphanumerics and following special characters are allowed. Special characters - [ ,'-./]"}
         },
         "patientSearch": { 


### PR DESCRIPTION
I have raised this PR to address the character length issue that came up in QA
Previously the address (sector) field was accepting anything more than 2 characters.
But QA observations indicate that character lengths of more than 1 should also be accepted 

I have made necessary change to address this.

Card for reference : https://bahmni.atlassian.net/browse/BAH-2758

@binduak @gokultw @kk-tw 