### PR TITLE
BAH-2922 | Added new location attribute type

### DIFF
--- a/masterdata/configuration/liquibase/liquibase.xml
+++ b/masterdata/configuration/liquibase/liquibase.xml
@@ -293,18 +293,18 @@
         </sql>
     </changeSet>
 
-    <changeSet id="BAH-2534-location-attribute-type-20230317-2922" author="Clinic-Config">
+    <changeSet id="BAH-2534-location-attribute-type-202303201129-2922" author="Clinic-Config">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">
-                SELECT count(*) FROM location_attribute_type where name="Address Header";
+                SELECT count(*) FROM location_attribute_type where name="Print Header";
             </sqlCheck>
         </preConditions>
-        <comment>Adding location attribute type Address Header</comment>
+        <comment>Adding location attribute type print Header</comment>
         <sql>
             INSERT INTO location_attribute_type (name, description, datatype, preferred_handler, min_occurs, creator, date_created,
             retired, uuid)
-            VALUES ("Address Header","Clinical address",
-            "org.openmrs.customdatatype.datatype.LongFreeTextDatatype", "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler", 0, 1, NOW(), 0, "6eba7e47-e1d5-4463-a2a7-7c1ee21c6029");
+            VALUES ("Print Header","Clinical address",
+            "org.openmrs.customdatatype.datatype.LongFreeTextDatatype", "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler", 0, 1, NOW(), 0, "6cd01df8-4418-4079-95bf-9716413dc8f5");
         </sql>
     </changeSet>
     <changeSet id="Reports-user-1612023-BAH-1911-cc" author="bahmni">

--- a/masterdata/configuration/liquibase/liquibase.xml
+++ b/masterdata/configuration/liquibase/liquibase.xml
@@ -303,7 +303,7 @@
         <sql>
             INSERT INTO location_attribute_type (name, description, datatype, preferred_handler, min_occurs, creator, date_created,
             retired, uuid)
-            VALUES ("Print Header","Clinical address",
+            VALUES ("Print Header","Clinical address used on header for any print",
             "org.openmrs.customdatatype.datatype.LongFreeTextDatatype", "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler", 0, 1, NOW(), 0, "6cd01df8-4418-4079-95bf-9716413dc8f5");
         </sql>
     </changeSet>

--- a/masterdata/configuration/liquibase/liquibase.xml
+++ b/masterdata/configuration/liquibase/liquibase.xml
@@ -292,18 +292,19 @@
             "org.openmrs.customdatatype.datatype.FreeTextDatatype", 0, 1, NOW(), 0, "07421454-e196-422d-a7c3-a045ffc5fac7");
         </sql>
     </changeSet>
-    <changeSet id="BAH-2534-location-attribute-type-20221108" author="Clinic-Config">
+
+    <changeSet id="BAH-2534-location-attribute-type-20230317-2922" author="Clinic-Config">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">
-                SELECT count(*) FROM location_attribute_type where name="Certificate Header";
+                SELECT count(*) FROM location_attribute_type where name="Address Header";
             </sqlCheck>
         </preConditions>
-        <comment>Adding location attribute type of  Certificate Header</comment>
+        <comment>Adding location attribute type Address Header</comment>
         <sql>
             INSERT INTO location_attribute_type (name, description, datatype, preferred_handler, min_occurs, creator, date_created,
             retired, uuid)
-            VALUES ("Certificate Header","Clinical address for print certificates.",
-            "org.openmrs.customdatatype.datatype.LongFreeTextDatatype", "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler", 0, 1, NOW(), 0, "07421454-e196-422d-a7c3-a045ffc5fac9");
+            VALUES ("Address Header","Clinical address",
+            "org.openmrs.customdatatype.datatype.LongFreeTextDatatype", "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler", 0, 1, NOW(), 0, "6eba7e47-e1d5-4463-a2a7-7c1ee21c6029");
         </sql>
     </changeSet>
     <changeSet id="Reports-user-1612023-BAH-1911-cc" author="bahmni">

--- a/openmrs/apps/customDisplayControl/constants/printConstants.json
+++ b/openmrs/apps/customDisplayControl/constants/printConstants.json
@@ -4,5 +4,5 @@
   "doctorRegistrationFieldValue": "MCI Reg Number",
   "providerIdentifier": "doctor",
   "patientAddress": {"line1": ["address1","address2","address3"], "line2": ["cityVillage","countyDistrict","stateProvince","postalCode"]},
-  "addressAndLocationAttributes": "Address Header"
+  "addressAndLocationAttributes": "Print Header"
 }

--- a/openmrs/apps/customDisplayControl/constants/printConstants.json
+++ b/openmrs/apps/customDisplayControl/constants/printConstants.json
@@ -4,5 +4,5 @@
   "doctorRegistrationFieldValue": "MCI Reg Number",
   "providerIdentifier": "doctor",
   "patientAddress": {"line1": ["address1","address2","address3"], "line2": ["cityVillage","countyDistrict","stateProvince","postalCode"]},
-  "addressAndLocationAttributes": "Certificate Header"
+  "addressAndLocationAttributes": "Address Header"
 }


### PR DESCRIPTION
Rename the location attributetype 'Certificate Header' to 'Address Header' as this attribute is no longer only used for certificates