### PR TITLE
BAH-3102 | Add. Configurable Additional Patient Identifiers In Patient Dashboard

### DIFF
--- a/openmrs/apps/clinical/dashboard.json
+++ b/openmrs/apps/clinical/dashboard.json
@@ -10,6 +10,7 @@
                 "displayOrder":0,
                 "ageLimit":100,
                 "patientAttributes":[],
+                "additionalPatientIdentifiers": [],
                 "addressFields":[
                     "address1",
                     "address2",


### PR DESCRIPTION
Jira -> [BAH-3102](https://bahmni.atlassian.net/browse/BAH-3102)

In this PR, a configurable property of "additionalPatientIdentifiers" is introduced. The purpose of this is to enable the visibility of additional patient identifiers for users with the privilege to view the patient dashboard.

To implement this feature, modifications are to be made to the [openmrs/apps/clinical/dashboard.json](https://github.com/BahmniIndiaDistro/clinic-config/blob/main/openmrs/apps/clinical/dashboard.json) file. Within the "sections/patientInformation", the "additionalPatientIdentifiers" property can be configured to specify the desired additional identifiers to be displayed.

For example, if "additionalPatientIdentifiers" is set to ["ABHA Address","ABHA Number"], the patient dashboard will display these additional identifiers alongside other patient information.

- When "additionalPatientIdentifiers" is configured:
![Screenshot 2023-07-13 at 12 49 57 PM](https://github.com/Bahmni/openmrs-module-bahmniapps/assets/121226043/4f2e2e2e-f7e1-41cc-844a-146b46cea8c0)

- When additionalPatientIdentifiers is left empty: 
![Screenshot 2023-07-13 at 12 50 26 PM](https://github.com/Bahmni/openmrs-module-bahmniapps/assets/121226043/70738154-5ce0-4387-81c7-8605f886e71c)