### PR TITLE
BAH-3181 | Added config element displayNameType for obs display control

### DIFF
--- a/openmrs/apps/clinical/dashboard.json
+++ b/openmrs/apps/clinical/dashboard.json
@@ -193,7 +193,8 @@
             "BMI Status"
           ],
           "showDetailsButton": true,
-          "numberOfVisits": 3
+          "numberOfVisits": 3,
+          "displayNameType": "FSN"
         },
         "hideEmptyDisplayControl": true
       },


### PR DESCRIPTION
used to specify whether to display in FSN. 

"someVitalsControl": {
        "type": "observation",
        "isObservation": true,
        "dashboardConfig": {
          "conceptNames": [
            "Height (cm)",
            "Weight (kg)",
            "Body mass index",
            "BMI Status"
          ],
          "displayNameType": "FSN"
        }
      }

if not FSN or none specified, the fallback is the default behavior of showing in short name or if SN is not present FSN. 