### PR TITLE
BAH-3532 | Fix. Print Types In Visits Config

### DIFF
--- a/openmrs/apps/clinical/visit.json
+++ b/openmrs/apps/clinical/visit.json
@@ -46,6 +46,22 @@
                     "conceptNames":[ ]
                 }
             },
+            "labOrders": {
+                "type": "labOrders",
+                "displayOrder": 4,
+                "config": {
+                    "translationKey": "VISIT_TITLE_LAB_ORDERS_KEY",
+                    "showChart": true,
+                    "showTable": false,
+                    "showOrders": true,
+                    "showNormalLabResults": false,
+                    "showCommentsExpanded": false,
+                    "showAccessionNotes": true,
+                    "numberOfVisits": 10,
+                    "showDetailsButton": false,
+                    "hideResultsColumn": false
+                }
+            },
             "prescriptions":{
                 "translationKey":"DASHBOARD_TITLE_PRESCRIPTIONS_KEY",
                 "type":"prescription",
@@ -139,7 +155,7 @@
                     "showAccessionNotes": true,
                     "numberOfVisits": 10,
                     "showDetailsButton": false,
-                    "hideVisitDate": true
+                    "hideResultsColumn": false
                 }
             },
             "radiologyOrderControl":  {


### PR DESCRIPTION
JIRA -> [BAH-3532](https://bahmni.atlassian.net/browse/BAH-3532)

This PR addresses an issue encountered in the Bahmni Lite refactorings and release, where  Lab results are not appearing in the Visit Summary section of the visits page, despite of recording results for all prescribed tests. To rectify the issue, the necessary modifications have been implemented in the visitSummary.html file. 
<img width="1377" alt="Screenshot 2024-02-06 at 6 14 47 PM" src="https://github.com/Bahmni/clinic-config/assets/102500787/7192b60a-1757-40d8-b02f-611551474f2d">
