### PR TITLE
BAH-3650 | Add. Event Trigger To Publish Image

### DIFF
--- a/.github/workflows/build_upload.yml
+++ b/.github/workflows/build_upload.yml
@@ -8,6 +8,12 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
     paths-ignore:
       - "**.md"
+  workflow_run:
+    workflows: [Pull Translations from Transifex]
+    types: [completed]
+    branches:
+      - main
+      - 'release-*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
JIRA -> [BAH-3650](https://bahmni.atlassian.net/browse/BAH-3650)

In this PR, an workflow based event trigger has been added to the Build and Publish clinic-config workflow. The Build and Publish clinic-config workflow was not getting triggered as the commit action in the Pull Translations From Transifex workflow run can’t trigger a new workflow run [(Refer comment)](https://github.com/orgs/community/discussions/27028#discussioncomment-3254360). The changes added will programmatically trigger Build and Publish clinic-config once the Pull Translations From Transifex workflow is successfully completed.