### PR TITLE
BAH-4654 | Add. Edit Configurations for Medications

### DIFF
--- a/openmrs/apps/clinical/v2/dashboards/general.json
+++ b/openmrs/apps/clinical/v2/dashboards/general.json
@@ -91,7 +91,17 @@
       "controls": [
         {
           "type": "treatment",
-          "requiredPrivileges": ["Get Orders"]
+          "requiredPrivileges": ["Get Orders"],
+          "config": {
+            "actions": [
+              {
+                "label": "Edit",
+                "type": "edit",
+                "encounterType": "Consultation",
+                "requiredPrivilege": ["Edit Orders"]
+              }
+            ]
+          }
         }
       ]
     },


### PR DESCRIPTION
## Summary

Adds edit action configuration for the Medications widget in the clinic-config dashboard JSON files. Same changes as [standard-config#119](https://github.com/Bahmni/standard-config/pull/119) for the clinic deployment.

## Changes

- **`general.json`** — adds `config.actions` array to the Medications `treatment` control with `type: "edit"`, `encounterType: "Consultation"`, `requiredPrivilege: ["Edit Orders"]`

## Related PRs
| Repo | PR | Purpose |
|------|----|---------|
| bahmni-apps-frontend | [#411](https://github.com/Bahmni/bahmni-apps-frontend/pull/411) | Frontend: Edit Medications feature |
| bahmni-module-fhir2-addl-extension | [#71](https://github.com/Bahmni/bahmni-module-fhir2-addl-extension/pull/71) | Backend: priorPrescription translation |
| standard-config | [#119](https://github.com/Bahmni/standard-config/pull/119) | Same config for standard deployment |

🤖 Generated with [Claude Code](https://claude.com/claude-code)