### PR TITLE
BAH-4709 | Part 2 | Fix critical security vulnerabilities on docker images

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.3
+FROM alpine:3.22
 
 COPY openmrs /etc/bahmni_config/openmrs
 COPY masterdata /etc/bahmni_config/masterdata


### PR DESCRIPTION
## What Changed
- `package/docker/Dockerfile`: Bumped Alpine base image from `alpine:3.18.3` → `alpine:3.22`

## Why
Trivy security scan reported **6 HIGH + 28 MEDIUM + 4 LOW** vulnerabilities on the `bahmni/clinic-config` image ([security report](https://github.com/Bahmni/security-reports/commit/ca55dc013d4439769f9d6de19ed0e651dddcbccf)). Alpine 3.18 reached **EOL in May 2025**; all findings originate from the outdated base layer. Bumping to Alpine 3.22 (currently supported, EOL Nov 2026) eliminates these vulnerabilities.

## Vulnerability Reduction

| Severity | Before (alpine:3.18.3) | After (alpine:3.22.4) |
|---|---|---|
| CRITICAL | 0 | **0** |
| HIGH | 6 | **0** |
| MEDIUM | 28 | **0** |
| LOW | 4 | **0** |

*Verified locally with Trivy v0.70.0 (DB updated 2026-05-22).*

## How Tested
- [x] `docker build -f package/docker/Dockerfile -t bah-4709-test .` — succeeded (alpine:3.22.4 pulled, all build steps passed)
- [x] `trivy image --severity CRITICAL,HIGH,MEDIUM,LOW --scanners vuln bah-4709-test:latest` — **0 vulnerabilities** found
- [x] Runtime smoke test: container starts, `start.sh` executes cleanly, `/usr/local/bahmni_config/{openmrs,masterdata}` populated correctly
- [ ] No automated Dockerfile tests exist in this repo

[BAH-4709]: https://bahmni.atlassian.net/browse/BAH-4709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BAH-4708]: https://bahmni.atlassian.net/browse/BAH-4708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ