### PR TITLE
BAH-4689 | Add. Stop action configurations

### DIFF
--- a/openmrs/apps/clinical/v2/app.json
+++ b/openmrs/apps/clinical/v2/app.json
@@ -94,6 +94,17 @@
         ]
       },
       {
+        "type": "stopMedications",
+        "metadata": {},
+        "encounterTypes": ["Consultation"],
+        "privileges": ["Edit Orders"],
+        "attributes": [
+          { "name": "stopDate", "required": true },
+          { "name": "stopReason", "required": true },
+          { "name": "note", "required": false }
+        ]
+      },
+      {
         "type": "observationForms",
         "metadata": {},
         "encounterTypes": ["Consultation"],

--- a/openmrs/apps/clinical/v2/dashboards/general.json
+++ b/openmrs/apps/clinical/v2/dashboards/general.json
@@ -99,6 +99,12 @@
                 "type": "edit",
                 "encounterType": "Consultation",
                 "requiredPrivilege": ["Edit Orders"]
+              },
+              {
+                "label": "Stop",
+                "type": "stop",
+                "encounterType": "Consultation",
+                "requiredPrivilege": ["Edit Orders"]
               }
             ]
           }

--- a/openmrs/i18n/clinical/locale_en.json
+++ b/openmrs/i18n/clinical/locale_en.json
@@ -109,5 +109,6 @@
   "VACCINATION_INPUT_CONTROL_LABEL": "Vaccinations",
   "CLINICAL_PRINT_MEDICATION_PRESCRIPTION_KEY": "Print latest medications",
   "MODULE_LABEL_ACTIVE_LEGACY_KEY": "Active (Legacy)",
-  "MODULE_LABEL_ALL_LEGACY_KEY": "All (Legacy)"
+  "MODULE_LABEL_ALL_LEGACY_KEY": "All (Legacy)",
+  "STOP_ACTION_LABEL": "Stop"
 }

--- a/openmrs/i18n/clinical/locale_es.json
+++ b/openmrs/i18n/clinical/locale_es.json
@@ -95,5 +95,6 @@
   "VACCINATION_INPUT_CONTROL_LABEL": "Vacunas",
   "DOCUMENTS_ATTACHMENTS": "Adjuntos",
   "CLINICAL_PRINT_MEDICATION_PRESCRIPTION_KEY": "Imprimir los últimos medicamentos",
-  "MODULE_LABEL_ALL_LEGACY_KEY": "Todo (heredado)"
+  "MODULE_LABEL_ALL_LEGACY_KEY": "Todo (heredado)",
+  "STOP_ACTION_LABEL": "Detener"
 }


### PR DESCRIPTION
## Summary

Adds stop action configuration for the Medications widget and `stopMedications` input control for the clinic deployment. Same changes as [standard-config#137](https://github.com/Bahmni/standard-config/pull/137).

## Changes

- **`general.json`** — adds stop action to treatment control with `type: "stop"`, `encounterType: "Consultation"`, `requiredPrivilege: ["Edit Orders"]`
- **`app.json`** — adds `stopMedications` input control to `consultationPad.inputControls` with stop date (required), stop reason (required), note (optional)
- **`locale_en.json`** / **`locale_es.json`** — adds `STOP_ACTION_LABEL` translation

## Related PRs
| Repo | PR | Purpose |
|------|----|---------|
| bahmni-apps-frontend | [#474](https://github.com/Bahmni/bahmni-apps-frontend/pull/474) | Frontend: Stop Medications feature |
| bahmni-module-fhir2-addl-extension | [#83](https://github.com/Bahmni/bahmni-module-fhir2-addl-extension/pull/83) | FHIR translator: statusReason, dateStopped, note |
| standard-config | [#137](https://github.com/Bahmni/standard-config/pull/137) | Same config for standard deployment |

🤖 Generated with [Claude Code](https://claude.com/claude-code)