### PR TITLE
BAH-4582 | Fix. Convert prescription dates to user's local timezone in print template

### DIFF
--- a/print-templates/prescriptions/compute.js
+++ b/print-templates/prescriptions/compute.js
@@ -50,9 +50,9 @@ module.exports = {
         return {
           drugName:           dosageForm ? `${baseName} (${dosageForm})` : baseName,
           dosageInstructions: buildDosageInstructions(mr.dosageInstruction),
-          startDate:          mr.authoredOn ?? '',
+          startDate:          toLocalDate(mr.dosageInstruction?.[0]?.timing?.event?.[0] ?? mr.authoredOn, context.timeZone),
           stopped,
-          stoppedDate:        stopped ? fhirPath(mr, 'meta.lastUpdated') ?? '' : '',
+          stoppedDate:        stopped ? toLocalDate(fhirPath(mr, 'meta.lastUpdated'), context.timeZone) : '',
           treatmentNotes:     parseAdditionalInstructions(mr.dosageInstruction?.[0]?.text),
         };
       }),
@@ -68,7 +68,7 @@ module.exports = {
       village,
       postalAddress,
       district,
-      visitDate:    firstStart ?? '',
+      visitDate:    toLocalDate(firstStart, context.timeZone),
       medications,
     };
   },
@@ -133,5 +133,12 @@ function parseAdditionalInstructions(text) {
 function durationLabel(code) {
   const map = { s: 'Seconds', min: 'Minutes', h: 'Hours', d: 'Days', wk: 'Weeks', mo: 'Months', a: 'Years' };
   return map[code] ?? code ?? '';
+}
+
+function toLocalDate(value, timeZone) {
+  if (!value || !timeZone) return value ?? '';
+  const date = new Date(value);
+  if (isNaN(date.getTime())) return value;
+  return date.toLocaleString('sv-SE', { timeZone });
 }
 


### PR DESCRIPTION
## Summary
- Add `toLocalDate` helper in prescriptions `compute.js` that converts UTC dates to the user's local timezone using the `timeZone` passed from the frontend context.
- Apply `toLocalDate` to `startDate`, `stoppedDate`, and `visitDate` before they reach the `dateFormat` template filter.

## Related PR
- [bahmni-apps-frontend](https://github.com/Bahmni/bahmni-apps-frontend/pull/488) — sends `timeZone` in render context

## Test plan
- [ ] Open a patient's clinical dashboard
- [ ] Prescribe a medication and save
- [ ] Click "Print Prescription"
- [ ] Verify start date, stopped date, and visit date display in the correct local timezone
- [ ] Verify edge case: medication created near midnight local time shows the correct date