### PR TITLE
BAH-4795 | Add Semgrep SAST CI workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,31 @@
+name: Semgrep SAST
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: '24 13 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      # semgrep/semgrep:1.165.0 — pinned by digest; bump manually when needed
+      image: semgrep/semgrep@sha256:bd2ada83c7aa5a60e07d86ee84ba0c12282264781c8d783be5a912549a94394f
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+      - run: semgrep scan --config auto --sarif --output semgrep.sarif
+        continue-on-error: true
+      - uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+        if: always() && hashFiles('semgrep.sarif') != ''
+        with:
+          sarif_file: semgrep.sarif


### PR DESCRIPTION
## Summary

Adds `.github/workflows/semgrep.yml`. Runs [Semgrep Community Edition](https://docs.semgrep.dev/deployment/oss-deployment) static analysis on PRs, pushes to the default branch, and weekly. Findings upload to the Security tab (Code Scanning) via SARIF.

Part of the org-wide rollout tracked in [BAH-4795](https://bahmni.atlassian.net/browse/BAH-4795). Template validated on [bahmni-core#330](https://github.com/Bahmni/bahmni-core/pull/330).

## Phase 1 — non-blocking

`continue-on-error: true` so existing findings do not block PRs. Findings still surface in the Security tab. A follow-up will flip to blocking with `--baseline-ref` once baselines are triaged.

## Cost: $0

Semgrep Community Edition (LGPL-2.1) + public registry rules + free GitHub Code Scanning on public repos. No `SEMGREP_APP_TOKEN`, no Semgrep Cloud account.

## Supply-chain hardening

- Container image and actions pinned to immutable SHAs/digests
- `persist-credentials: false` on checkout (least privilege)
- SARIF upload guarded by `hashFiles()` so the workflow stays truly non-blocking if Semgrep crashes before producing the SARIF

## Test plan

- [ ] Workflow appears in Actions tab and runs on this PR
- [ ] Scan completes (success or non-zero — both OK in phase 1)
- [ ] SARIF uploads to Security tab (visible to write+ collaborators)
- [ ] Subsequent push to default branch triggers the workflow

[BAH-4795]: https://bahmni.atlassian.net/browse/BAH-4795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ