### PR TITLE
BAH-4720 | Fix. Print prescription to show Note as Treatment Notes for new Bahmni medications

### DIFF
--- a/print-templates/prescriptions/compute.js
+++ b/print-templates/prescriptions/compute.js
@@ -53,7 +53,7 @@ module.exports = {
           startDate:          toLocalDate(mr.dosageInstruction?.[0]?.timing?.event?.[0] ?? mr.authoredOn, context.timeZone),
           stopped,
           stoppedDate:        stopped ? toLocalDate(fhirPath(mr, 'meta.lastUpdated'), context.timeZone) : '',
-          treatmentNotes:     parseAdditionalInstructions(mr.dosageInstruction?.[0]?.text),
+          treatmentNotes:     parseAdditionalInstructions(mr.dosageInstruction?.[0]?.text) || mr.note?.[0]?.text || '',
         };
       }),
     }));


### PR DESCRIPTION
MedicationRequest.note (comment_to_fulfiller) is used by new Bahmni for patient-facing additional instructions, while old Bahmni stored them in dosage.text JSON as additionalInstructions. The print template only read the JSON path, missing notes saved via new Bahmni.

Add fallback to mr.note[0].text so both old and new medications print their treatment notes correctly.

This is a temporary work around and will be fully addressed in the tech-debt card