### PR TITLE
BAH-4801. Clean up obsolete BAH-4655 registration encounter code

### DIFF
--- a/openmrs/i18n/admin/locale_en.json
+++ b/openmrs/i18n/admin/locale_en.json
@@ -41,7 +41,6 @@
   "CLOSE_VISIT_MESSAGE": "User {{userId}} closed {{params.visitType}} visit of patient {{patientId}}.",
   "CLOSE_VISIT_FAILED_MESSAGE": "User {{userId}} tries to close {{params.visitType}} visit of patient {{patientId}}, but failed.",
   "EDIT_ENCOUNTER_MESSAGE": "User {{userId}} edited {{params.encounterType}} encounter of patient {{patientId}}",
-  "CREATE_ENCOUNTER_MESSAGE": "User {{userId}} created {{params.encounterType}} encounter for patient {{patientId}}",
   "MODULE_LABEL_REGISTRATION_KEY": "Registration",
   "MODULE_LABEL_CLINICAL_KEY": "Clinical",
   "MODULE_LABEL_INPATIENT_KEY": "InPatient",


### PR DESCRIPTION
CREATE_ENCOUNTER_MESSAGE added as part of BAH-4655 is redundant. 