### PR TITLE
BAH-4786 | Add. Enable appointment reasons and a custom ValueSet for appointment reasons

### DIFF
--- a/masterdata/configuration/concepts/appointment_resaons.csv
+++ b/masterdata/configuration/concepts/appointment_resaons.csv
@@ -1,0 +1,5 @@
+Uuid,Void/Retire,Same as mappings,Fully specified name:en,Short name:en,Description:en,Data class,Data type,Members,_version:1,_order:1200
+3b24bff4-31fb-4982-bef8-341ce76d9e61,,SNOMED-CT:406151001,Post-discharge follow-up,Post-discharge follow-up,Post-discharge follow-up,Finding,N/A,,,
+b074e5b0-d266-4603-9f5d-ec1c9057cc3e,,SNOMED-CT:302805002,Preventive Care,Preventive Care,Preventive Care,Misc,N/A,,,
+ed8d2230-a4bd-4f4c-ad23-253454f3583d,,SNOMED-CT:183484003,Day care treatment,Day care treatment,Day care treatment,Misc,N/A,,,
+bb4d670e-64a1-4f37-bb02-49d2a8119bc2,,,Appointment Reasons,Appointment Reasons,ValueSet with the list of appointment reasons,Misc,N/A,164081AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;160523AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;1622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;1623AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;5485AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;3b24bff4-31fb-4982-bef8-341ce76d9e61;b074e5b0-d266-4603-9f5d-ec1c9057cc3e;ed8d2230-a4bd-4f4c-ad23-253454f3583d,,

--- a/openmrs/apps/appointments/app.json
+++ b/openmrs/apps/appointments/app.json
@@ -61,6 +61,8 @@
     "recurrence": {
       "defaultNumberOfOccurrences": 10
     },
-    "additionalInfoColumns": {"Language": "English"}
+    "additionalInfoColumns": {"Language": "English"},
+    "enableAppointmentReasons": true,
+    "appointmentReasonConceptSet": "Appointment Reasons"
   }
 }


### PR DESCRIPTION
This PR adds configuration to enable appointment reasons and set a ValueSet for appointment reasons. This value set is a reference and implementations can extend the list as needed.