### PR TITLE
Fix extension privileges to use requiredPrivileges array

### DIFF
--- a/openmrs/apps/documentUpload/extension-Patient Document.json
+++ b/openmrs/apps/documentUpload/extension-Patient Document.json
@@ -11,7 +11,7 @@
     },
     "label": "Active Patients",
     "order": 1,
-    "requiredPrivilege": ["Add DocumentReference", "Get DocumentReference"]
+    "requiredPrivileges": ["Add DocumentReference", "Get DocumentReference"]
   },
   "bahmniDocUploadPatientsSearchActivePatients": {
     "id": "bahmni.docUpload.patients.search.activePatients",
@@ -37,7 +37,7 @@
     },
     "label": "All Patients",
     "order": 3,
-    "requiredPrivilege": ["Add DocumentReference", "Get DocumentReference"]
+    "requiredPrivileges": ["Add DocumentReference", "Get DocumentReference"]
   },
   "bahmniDocUploadPatientsSearchAllPatients": {
     "id": "bahmni.docUpload.patients.search.allPatients",


### PR DESCRIPTION
Fix extension privileges array support by using 'requiredPrivileges' (plural) for array values and 'requiredPrivilege' (singular) for string values. This enables proper OR logic for multiple privileges - user needs ANY ONE of the required privileges to access the feature.