### PR TITLE
BAH-4911 | Add. Default Search Config For Registration

### DIFF
--- a/openmrs/apps/registration/v2/app.json
+++ b/openmrs/apps/registration/v2/app.json
@@ -1,56 +1,4 @@
 {
-  "patientSearch": {
-    "customAttributes": [
-      {
-        "translationKey": "REGISTRATION_PATIENT_SEARCH_DROPDOWN_PHONE_NUMBER",
-        "fields": ["phoneNumber", "alternatePhoneNumber"],
-        "expectedFields": [
-          {
-            "field": "phoneNumber",
-            "translationKey": "REGISTRATION_PATIENT_SEARCH_HEADER_PHONE_NUMBER"
-          },
-          {
-            "field": "alternatePhoneNumber",
-            "translationKey": "REGISTRATION_PATIENT_SEARCH_HEADER_ALTERNATE_PHONE_NUMBER"
-          }
-        ],
-        "type": "person"
-      },
-      {
-        "translationKey": "REGISTRATION_PATIENT_SEARCH_DROPDOWN_EMAIL",
-        "fields": ["email"],
-        "expectedFields": [
-          {
-            "field": "email",
-            "translationKey": "REGISTRATION_PATIENT_SEARCH_HEADER_EMAIL"
-          }
-        ],
-        "type": "person"
-      },
-      {
-        "translationKey": "REGISTRATION_PATIENT_SEARCH_DROPDOWN_VILLAGE",
-        "fields": ["city_village"],
-        "expectedFields": [
-          {
-            "field": "city_village",
-            "translationKey": "REGISTRATION_PATIENT_SEARCH_HEADER_VILLAGE"
-          }
-        ],
-        "type": "address"
-      },
-      {
-        "translationKey": "REGISTRATION_PATIENT_SEARCH_DROPDOWN_LOCALITY",
-        "fields": ["address2"],
-        "expectedFields": [
-          {
-            "field": "address2",
-            "translationKey": "REGISTRATION_PATIENT_SEARCH_HEADER_LOCALITY"
-          }
-        ],
-        "type": "address"
-      }
-    ]
-  },
   "defaultVisitType": "OPD",
   "patientInformation": {
     "defaultIdentifierPrefix": "ABC",
@@ -200,5 +148,17 @@
       "requiredPrivilege": "View Patients"
     }
   ],
-  "registrationEncounterType": "REG"
+  "registrationEncounterType": "REG",
+  "extensions": [
+    {
+      "id": "bahmni.registration.v2.search.registrationSearch",
+      "extensionPointId": "org.bahmni.registration.v2.search",
+      "translationKey": "REGISTRATION_DEFAULT_SEARCH_LABEL",
+      "requiredPrivileges": ["app:registration"],
+      "extensionParams": {
+        "searchHandler": "defaultSearch",
+        "configUrl": "/bahmni_config/openmrs/apps/registration/v2/extensions/defaultSearchConfig.json"
+      }
+    }
+  ]
 }

--- a/openmrs/apps/registration/v2/extensions/defaultSearchConfig.json
+++ b/openmrs/apps/registration/v2/extensions/defaultSearchConfig.json
@@ -1,0 +1,52 @@
+{
+    "customAttributes": [
+      {
+        "translationKey": "REGISTRATION_PATIENT_SEARCH_DROPDOWN_PHONE_NUMBER",
+        "fields": ["phoneNumber", "alternatePhoneNumber"],
+        "expectedFields": [
+            {
+              "field": "phoneNumber",
+              "translationKey": "REGISTRATION_PATIENT_SEARCH_HEADER_PHONE_NUMBER"
+            }, 
+            {
+              "field": "alternatePhoneNumber",
+              "translationKey": "REGISTRATION_PATIENT_SEARCH_HEADER_ALTERNATE_PHONE_NUMBER"
+            }
+        ],
+        "type": "person"
+      },
+      {
+        "translationKey": "REGISTRATION_PATIENT_SEARCH_DROPDOWN_EMAIL",
+        "fields": ["email"],
+        "expectedFields": [
+            {
+              "field": "email",
+              "translationKey": "REGISTRATION_PATIENT_SEARCH_HEADER_EMAIL"
+            }
+        ],
+        "type": "person"
+      },
+      {
+        "translationKey": "REGISTRATION_PATIENT_SEARCH_DROPDOWN_VILLAGE",
+        "fields": ["city_village"],
+        "expectedFields": [
+            {
+              "field": "city_village",
+              "translationKey": "REGISTRATION_PATIENT_SEARCH_HEADER_VILLAGE"
+            }
+        ],
+        "type": "address"
+      },
+      {
+        "translationKey": "REGISTRATION_PATIENT_SEARCH_DROPDOWN_LOCALITY",
+        "fields": ["address2"],
+        "expectedFields": [
+            {
+              "field": "address2",
+              "translationKey": "REGISTRATION_PATIENT_SEARCH_HEADER_LOCALITY"
+            }
+        ],
+        "type": "address"
+      }
+    ]
+}

--- a/openmrs/i18n/registration/locale_en.json
+++ b/openmrs/i18n/registration/locale_en.json
@@ -58,5 +58,6 @@
   "REGISTRATION_PHONE_NUMBER_VALIDATION": "Phone number should have 6 to 15 digits",
   "REGISTRATION_ALTERNATE_PHONE_NUMBER_VALIDATION": "Alternate phone number should have 6 to 15 digits",
 
-  "PATIENT_DASHBOARD_REDIRECT": "Patient Dashboard"
+  "PATIENT_DASHBOARD_REDIRECT": "Patient Dashboard",
+  "REGISTRATION_DEFAULT_SEARCH_LABEL": "Search"
 }

--- a/openmrs/i18n/registration/locale_es.json
+++ b/openmrs/i18n/registration/locale_es.json
@@ -21,5 +21,6 @@
   "REGISTRATION_INSTITUTE_ADDRESS": "Ganiyari, District - Bilaspur",
   "FEE_INFORMATION_LOCALE_KEY": "Fee Information",
   "NUTRITIONAL_VALUES_LOCALE_KEY": "Nutritional Values",
-  "REGISTRATION_PRINT_WITH_BARCODE": "Bar<u>c</u>ode Print"
+  "REGISTRATION_PRINT_WITH_BARCODE": "Bar<u>c</u>ode Print",
+  "REGISTRATION_DEFAULT_SEARCH_LABEL": "Buscar"
 }


### PR DESCRIPTION
JIRA → [BAH-4911](https://bahmni.atlassian.net/browse/BAH-4911)

## Description

Refactors SearchPatient from a directly-prop-driven component into a self-contained search extension widget. It now accepts extensionParams (consistent with CommonSearchWidget) and fetches its own configuration via configUrl, enabling it to be registered and rendered through the extension system in RegistrationList without any app-level prop wiring. The patientSearch configuration block is removed from RegistrationConfig entirely, as it is now owned by the widget's own config URL.

This PR carves out the default search config into a file of it's own.

[BAH-4911]: https://bahmni.atlassian.net/browse/BAH-4911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ