### PR TITLE
BAH-4689 | Add stop medication config

### DIFF
--- a/openmrs/apps/clinical/v2/app.json
+++ b/openmrs/apps/clinical/v2/app.json
@@ -97,7 +97,7 @@
       {
         "type": "stopMedications",
         "metadata": {
-          "stoppedOrderReasonConceptSet": "86039fe9-f50d-4009-b32d-89daa38dce72"
+          "stoppedOrderReasonConceptSet": "d737badf-5e07-11ef-8f7c-0242ac120002"
         },
         "encounterTypes": ["Consultation"],
         "privileges": ["Edit Orders"],

--- a/openmrs/apps/clinical/v2/app.json
+++ b/openmrs/apps/clinical/v2/app.json
@@ -97,7 +97,7 @@
       {
         "type": "stopMedications",
         "metadata": {
-          "stopOrderedReasonConceptSet": "Stopped Order Reason"
+          "stoppedOrderReasonConceptSet": "Stopped Order Reason"
         },
         "encounterTypes": ["Consultation"],
         "privileges": ["Edit Orders"],

--- a/openmrs/apps/clinical/v2/app.json
+++ b/openmrs/apps/clinical/v2/app.json
@@ -96,7 +96,9 @@
       },
       {
         "type": "stopMedications",
-        "metadata": {},
+        "metadata": {
+          "stopOrderedReasonConceptSet": "Stopped Order Reason"
+        },
         "encounterTypes": ["Consultation"],
         "privileges": ["Edit Orders"],
         "attributes": [

--- a/openmrs/apps/clinical/v2/app.json
+++ b/openmrs/apps/clinical/v2/app.json
@@ -97,7 +97,7 @@
       {
         "type": "stopMedications",
         "metadata": {
-          "stoppedOrderReasonConceptSet": "Stopped Order Reason"
+          "stoppedOrderReasonConceptSet": "d737badf-5e07-11ef-8f7c-0242ac120002"
         },
         "encounterTypes": ["Consultation"],
         "privileges": ["Edit Orders"],

--- a/openmrs/apps/clinical/v2/app.json
+++ b/openmrs/apps/clinical/v2/app.json
@@ -97,7 +97,7 @@
       {
         "type": "stopMedications",
         "metadata": {
-          "stoppedOrderReasonConceptSet": "d737badf-5e07-11ef-8f7c-0242ac120002"
+          "stoppedOrderReasonConceptSet": "86039fe9-f50d-4009-b32d-89daa38dce72"
         },
         "encounterTypes": ["Consultation"],
         "privileges": ["Edit Orders"],

--- a/openmrs/apps/clinical/v2/medication.json
+++ b/openmrs/apps/clinical/v2/medication.json
@@ -72,5 +72,4 @@
             "route": "Oral"
         }
     },
-    "stopOrderedReasonConceptSet": "Stopped Order Reason"
 }

--- a/openmrs/apps/clinical/v2/medication.json
+++ b/openmrs/apps/clinical/v2/medication.json
@@ -71,5 +71,5 @@
             "doseUnits": "Tablet",
             "route": "Oral"
         }
-    },
+    }
 }

--- a/openmrs/apps/clinical/v2/medication.json
+++ b/openmrs/apps/clinical/v2/medication.json
@@ -71,5 +71,6 @@
             "doseUnits": "Tablet",
             "route": "Oral"
         }
-    }
+    },
+    "stopOrderedReasonConceptSet": "Stopped Order Reason"
 }


### PR DESCRIPTION
## Summary

- Moved `stoppedOrderReasonConceptSet` from `medication.json` into `stopMedications` inputControl `metadata` in `app.json` — config now lives alongside the form that uses it
- Uses concept set UUID directly (`d737badf-5e07-11ef-8f7c-0242ac120002`) to call `ValueSet/$expand` in a single FHIR call instead of two

## Related PRs
- Frontend: Bahmni/bahmni-apps-frontend#600
- Backend: Bahmni/bahmni-module-fhir2-addl-extension#105