### PR TITLE
BAH-4581 | Add print registration card config

### DIFF
--- a/openmrs/apps/registration/v2/app.json
+++ b/openmrs/apps/registration/v2/app.json
@@ -148,6 +148,12 @@
       "requiredPrivilege": "View Patients"
     }
   ],
+  "printOptions": [
+    {
+      "translationKey": "REGISTRATION_PRINT_REGISTRATION_CARD",
+      "templateId": "REG_CARD_V1"
+    }
+  ],
   "registrationEncounterType": "REG",
   "extensions": [
     {


### PR DESCRIPTION
Register the REG_CARD_V1 print template as a top-level printOptions entry for the registration v2 app, so the Print Registration Card button renders in the registration footer.

Uses the REGISTRATION_PRINT_REGISTRATION_CARD translation key rather than the legacy REGISTRATION_PRINT_REG_CARD_KEY, which carries <u> accelerator markup used by the AngularJS registration app.