### PR TITLE
BAH-5046 | Fix. Use FSN instead of UUID for stoppedOrderReasonConceptSet

### DIFF
--- a/openmrs/apps/clinical/v2/app.json
+++ b/openmrs/apps/clinical/v2/app.json
@@ -97,7 +97,7 @@
       {
         "type": "stopMedications",
         "metadata": {
-          "stoppedOrderReasonConceptSet": "bd685ab8-f496-11ed-b02c-0242ac150003"
+          "stoppedOrderReasonConceptSet": "Stopped Order Reason"
         },
         "encounterTypes": ["Consultation"],
         "privileges": ["Edit Orders"],


### PR DESCRIPTION
## Summary
- Replace hardcoded UUID in `stoppedOrderReasonConceptSet` with the concept's Fully Specified Name (`"Stopped Order Reason"`)
- UUIDs differ across environments, causing the stopped order reason API to fail in environments like beta-lite and dev-lite
- Using the FSN is environment-agnostic and already supported by the frontend

## Test plan
- [ ] Verify stop medication reason dropdown loads correctly in beta-lite
- [ ] Verify stop medication reason dropdown loads correctly in dev-lite
- [ ] Verify no regression in environments where UUID was previously working