### PR TITLE
BAH-5094 | Add. Procedures section to clinical dashboard

### DIFF
--- a/openmrs/apps/clinical/v2/dashboards/general.json
+++ b/openmrs/apps/clinical/v2/dashboards/general.json
@@ -162,6 +162,19 @@
       ]
     },
     {
+      "name": "Procedures",
+      "translationKey": "DASHBOARD_TITLE_PROCEDURES_KEY",
+      "icon": "fa-bed-pulse",
+      "controls": [
+        {
+          "type": "ordersControl",
+          "config": {
+            "orderType": "Procedure Order"
+          }
+        }
+      ]
+    },
+    {
       "name": "Forms",
       "translationKey": "DASHBOARD_TITLE_FORMS_DISPLAY_CONTROL_KEY",
       "icon": "fa-clipboard-list",


### PR DESCRIPTION
## Summary
- Add Procedures widget to the v2 clinical patient dashboard in `general.json`
- Uses `ordersControl` type with `orderType: "Procedure Order"` — displays ordered procedures grouped by date after consultation

## Test plan
- [ ] Open a patient who has procedure orders saved
- [ ] Verify a "Procedures" section appears on the General Dashboard showing the ordered procedures

Jira: https://bahmni.atlassian.net/browse/BAH-5094